### PR TITLE
Update settings.py

### DIFF
--- a/shorts/settings.py
+++ b/shorts/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = '=q=w4rky_j3$i^00)_!pbn6p#qf!i^wof4^!%&+m!znu5+69oq'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 TEMPLATE_DEBUG = True
 


### PR DESCRIPTION
If entering unicode string like ń, I get standard Django error page. The reason of it is the DEBUG set to true.
